### PR TITLE
fix: 티켓 인증 API 경로 수정

### DIFF
--- a/App/services/TicketService.ts
+++ b/App/services/TicketService.ts
@@ -72,6 +72,6 @@ export async function getTicketFaceAuth(ticketId: number) {
 
 // 티켓 상태 checked_in으로 변경
 export async function certifyTicket(ticketId: number): Promise<TicketCertificationResponse> {
-  const res = await api.patch(`ticket/${ticketId}/certification/`);
+  const res = await api.patch(`tickets/${ticketId}/certification/`);
   return res.data;
 }


### PR DESCRIPTION
- 티켓 인증 API 호출 시 경로를 'ticket'에서 'tickets'로 변경

## #️⃣연관된 이슈

#129 

## 📝작업 내용

티켓 인증 API 경로 수정

### 스크린샷 (선택)
