### PR TITLE
fix: 결제 성공 시 ticketId 처리 수정

### DIFF
--- a/App/pages/events/PaymentScreen.tsx
+++ b/App/pages/events/PaymentScreen.tsx
@@ -264,14 +264,10 @@ export default function PaymentScreen() {
               });
               // 결제 성공 시 처리 (AxiosResponse 구조 반영)
 
-              navigation.navigate("내 티켓", {
-                screen: "FaceRegisterScreen",
-                params: { ticketId: 1, seatInfos },
               setTicketId(result.data.ticketId); // 결제 API 응답에서 발급된 ticketId(티켓 고유 ID)를 상태로 저장
               navigation.navigate('내 티켓', { // 내 티켓 화면으로 이동
                 screen: 'FaceRegisterScreen', // FaceRegisterScreen으로 이동
-                params: { ticketId: tempTicketId, seatInfos } // ticketId: 임시로 1로 고정하여 전달, seatInfos: 선택한 좌석 정보 배열을 FaceRegisterScreen으로 전달
-
+                params: { ticketId: result.data.ticketId, seatInfos } // ticketId: 임시로 1로 고정하여 전달, seatInfos: 선택한 좌석 정보 배열을 FaceRegisterScreen으로 전달
               });
             } catch (e) {
               setErrorMsg("결제 처리 중 오류가 발생했습니다.");


### PR DESCRIPTION
## #️⃣연관된 이슈

#133 

## 📝작업 내용

- 결제 API 응답에서 발급된 ticketId를 사용하도록 수정하여, 임시로 고정된 값(1) 대신 실제 ticketId를 전달하도록 변경함.

### 스크린샷 (선택)
