### PR TITLE
Feat:  jwt토큰 갱신 로직 수정

### DIFF
--- a/App/services/apiClient.ts
+++ b/App/services/apiClient.ts
@@ -11,7 +11,7 @@ const apiClient = axios.create({
   },
 });
 
-// 요청 인터셉터 (토큰 추가 등)
+// 요청 인터셉터 (accessToken 자동 부착)
 apiClient.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
     const token = await AsyncStorage.getItem("accessToken");
@@ -20,21 +20,85 @@ apiClient.interceptors.request.use(
     } else if (config.headers && config.headers.Authorization) {
       delete config.headers.Authorization;
     }
-
-    console.log("API 요청 헤더:", config.headers);
     return config;
   },
   (error) => Promise.reject(error)
 );
 
-// 응답 인터셉터 (에러 처리 등)
+// 토큰 갱신 상태 관리
+let isRefreshing = false;
+let failedQueue: any[] = [];
+
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach(prom => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+let onForceLogout: (() => void) | null = null;
+export const setForceLogoutHandler = (handler: () => void) => {
+  onForceLogout = handler;
+};
+
+const forceLogout = async () => {
+  await AsyncStorage.removeItem("accessToken");
+  await AsyncStorage.removeItem("refreshToken");
+  if (onForceLogout) onForceLogout(); // 콜백 호출
+};
+
 apiClient.interceptors.response.use(
-  (response: AxiosResponse) => {
-    return response;
-  },
-  (error: any) => {
-    // 에러 처리 로직
-    console.error("API Error:", error);
+  (response: AxiosResponse) => response,
+  async (error: any) => {
+    const originalRequest = error.config;
+
+    // accessToken 만료(401) & 재시도 안 한 경우
+    if (
+      error.response &&
+      error.response.status === 401 &&
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true;
+
+      if (isRefreshing) {
+        // 이미 갱신 중이면 큐에 넣고 기다림
+        return new Promise(function (resolve, reject) {
+          failedQueue.push({ resolve, reject });
+        })
+          .then((token) => {
+            originalRequest.headers.Authorization = "Bearer " + token;
+            return apiClient(originalRequest);
+          })
+          .catch((err) => Promise.reject(err));
+      }
+
+      isRefreshing = true;
+      try {
+        const refreshToken = await AsyncStorage.getItem("refreshToken");
+        if (!refreshToken) throw new Error("No refresh token");
+        // 실제 refresh 엔드포인트에 맞게 경로 수정
+        const res = await axios.post(
+          `${Constants.expoConfig?.extra?.API_BASE_URL}user/token/refresh/`,
+          { refresh: refreshToken }
+        );
+        const newAccessToken = res.data.access;
+        await AsyncStorage.setItem("accessToken", newAccessToken);
+        processQueue(null, newAccessToken);
+        originalRequest.headers.Authorization = "Bearer " + newAccessToken;
+        return apiClient(originalRequest);
+      } catch (err) {
+        processQueue(err, null);
+        // refreshToken도 만료 → 로그아웃 처리
+        await forceLogout();
+        return Promise.reject(err);
+      } finally {
+        isRefreshing = false;
+      }
+    }
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #175 

## 📝작업 내용

> Jwt access토큰 만료시 refresh토큰을 이용해 갱신하여 로그인이 유지되게 하고 refresh토큰 만료시 강제 로그아웃 하도록 수정

### 스크린샷 (선택)
